### PR TITLE
Follow redirects

### DIFF
--- a/src/ImageDownloader.php
+++ b/src/ImageDownloader.php
@@ -84,7 +84,8 @@ class ImageDownloader
         $this->_fileManager->open($fullPath, 'wb');
         $this->_curl->setParams([
             CURLOPT_FILE => $this->_fileManager->getInstance(),
-            CURLOPT_HEADER => 0
+            CURLOPT_HEADER => 0,
+            CURLOPT_FOLLOWLOCATION => true
         ]);
 
         // download file


### PR DESCRIPTION
I would recommend adding this. I had to bulk download some images from a cloud provider and they first did an annoying 301 redirect so this fixed my problem. This shouldn't break anything either, just allows curl to follow up to 5 redirects (by default.) If you don't want this on by default, I could always make this optional.